### PR TITLE
feat(h5)：对网页进行移动端适配，增加自适应布局和响应式元素和样式

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -28,7 +28,6 @@ declare module 'vue' {
     ClubBattleRecords: typeof import('./src/components/Club/ClubBattleRecords.vue')['default']
     ClubCarKing: typeof import('./src/components/ClubCarKing.vue')['default']
     ClubInfo: typeof import('./src/components/Club/ClubInfo.vue')['default']
-    copy: typeof import('./src/components/cards/HelperCard copy.vue')['default']
     DailyTaskCard: typeof import('./src/components/Daily/DailyTaskCard.vue')['default']
     DailyTaskStatus: typeof import('./src/components/Daily/DailyTaskStatus.vue')['default']
     FishHelperCard: typeof import('./src/components/cards/FishHelperCard.vue')['default']

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -312,3 +312,31 @@ img {
     font-size: var(--font-size-xl);
   }
 }
+
+// Arco Modal 移动端适配
+@media (max-width: 768px) {
+  .arco-modal {
+    width: auto !important;
+    max-width: 95vw !important;
+    margin: 0 auto !important;
+  }
+
+  .arco-modal-content {
+    padding: var(--spacing-sm) !important;
+    border-radius: var(--border-radius-medium) !important;
+  }
+
+  .arco-modal-header {
+    padding: var(--spacing-sm) var(--spacing-sm) !important;
+  }
+
+  .arco-modal-title {
+    font-size: var(--font-size-lg) !important;
+    line-height: 1.4 !important;
+  }
+
+  .arco-modal-body {
+    max-height: 70vh !important;
+    overflow-y: auto !important;
+  }
+}

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -100,3 +100,29 @@
   --border-medium: #6b7280;
   --border-dark: #9ca3af;
 }
+
+@media (max-width: 768px) {
+  :root {
+    --font-size-xs: 12px;
+    --font-size-sm: 13px;
+    --font-size-md: 15px;
+    --font-size-lg: 16px;
+    --font-size-xl: 18px;
+    --font-size-2xl: 22px;
+    --font-size-3xl: 28px;
+
+    --spacing-xs: 4px;
+    --spacing-sm: 8px;
+    --spacing-md: 12px;
+    --spacing-lg: 16px;
+    --spacing-xl: 24px;
+    --spacing-2xl: 32px;
+  }
+}
+
+@media (max-width: 640px) {
+  :root {
+    --font-size-md: 14px;
+    --spacing-md: 10px;
+  }
+}

--- a/src/components/Common/IdentityCard.vue
+++ b/src/components/Common/IdentityCard.vue
@@ -28,11 +28,16 @@
         </div>
       </div>
 
-      <div class="resources" v-if="hasRole">
+      <div class="resources" :class="{ collapsed: !isExpanded }" v-if="hasRole">
         <div v-for="res in resList" :key="res.label" class="res-item">
           <span class="label">{{ res.label }}</span>
           <span class="value">{{ res.value }}</span>
         </div>
+      </div>
+      <div v-if="hasRole && showExpand" class="resources-toggle">
+        <n-button text @click="isExpanded = !isExpanded">
+          {{ isExpanded ? '收起' : '展开全部' }}
+        </n-button>
       </div>
       <div v-else class="loading">正在获取角色信息...</div>
     </div>
@@ -85,6 +90,7 @@ const tokenStore = useTokenStore();
 
 const props = defineProps<{ visible?: boolean; embedded?: boolean }>();
 const emit = defineEmits(["close"]);
+const isExpanded = ref(false)
 
 const wsStatus = computed(() => {
   if (!tokenStore.selectedToken) return "disconnected";
@@ -195,7 +201,7 @@ const recruitFromItems = computed(() => getItemCount(items.value, 1001));
 const ironFromItems = computed(() => getItemCount(items.value, 1006));
 const jadeFromItems = computed(() => getItemCount(items.value, 1023));
 const advanceStoneFromItems = computed(() => getItemCount(items.value, 1003));
-//10002蓝玉 10003红玉 10101四圣碎片 
+//10002蓝玉 10003红玉 10101四圣碎片
 const blueJadeFromItems = computed(() => getItemCount(items.value, 10002));
 const redJadeFromItems = computed(() => getItemCount(items.value, 10003));
 const fourSaintFragmentFromItems = computed(() => getItemCount(items.value, 10101));
@@ -226,6 +232,8 @@ const resList = computed(() => [
   { label: "红玉", value: display(redJadeFromItems.value as any) },
   { label: "四圣碎片", value: display(fourSaintFragmentFromItems.value as any) }
 ]);
+
+const showExpand = computed(() => resList.value.length > 6);
 
 const initializeAvatar = () => {
   if (roleInfo.value && (roleInfo.value as any).headImg) {
@@ -293,7 +301,6 @@ watch(() => roleInfo.value, initializeAvatar, { deep: true });
 .identity-card {
   position: fixed;
   top: 0;
-  right: 16px;
   width: 360px;
   background: var(--bg-primary);
   border-radius: var(--border-radius-xl);
@@ -436,6 +443,24 @@ watch(() => roleInfo.value, initializeAvatar, { deep: true });
   font-weight: var(--font-weight-semibold);
 }
 
+@media (max-width: 768px) {
+  .card-header {
+    justify-content: center;
+    text-align: center;
+  }
+
+  .role-profile-content {
+    justify-content: center;
+    flex-wrap: wrap;
+    text-align: center;
+  }
+
+  .rank-section {
+    margin-left: 0;
+    justify-content: center;
+  }
+}
+
 .glow-border {
   position: absolute;
   inset: 0;
@@ -504,6 +529,12 @@ watch(() => roleInfo.value, initializeAvatar, { deep: true });
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 8px;
   margin-top: 10px;
+  --res-item-height: 44px;
+}
+
+.resources.collapsed {
+  max-height: calc((var(--res-item-height) + 8px) * 2 + 8px);
+  overflow: hidden;
 }
 
 .res-item {
@@ -511,9 +542,17 @@ watch(() => roleInfo.value, initializeAvatar, { deep: true });
   border: 1px solid var(--border-light);
   border-radius: 10px;
   padding: 8px 10px;
+  min-height: var(--res-item-height);
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.resources-toggle {
+  margin-top: var(--spacing-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
 }
 
 .res-item .label {

--- a/src/components/GameStatus.vue
+++ b/src/components/GameStatus.vue
@@ -452,7 +452,7 @@ onUnmounted(() => {
 <style scoped lang="scss">
 .game-status-container {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: var(--spacing-lg);
   padding: var(--spacing-lg);
 
@@ -465,13 +465,18 @@ onUnmounted(() => {
 
   // 在中等屏幕上确保有足够空间
   @media (max-width: 1200px) {
-    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 
   // 在较小屏幕上使用单列布局
   @media (max-width: 900px) {
     grid-template-columns: 1fr;
     gap: var(--spacing-md);
+  }
+
+  @media (max-width: 768px) {
+    grid-template-columns: minmax(0, 1fr);
+    padding: var(--spacing-md);
   }
 }
 

--- a/src/components/Team/TeamFormation.vue
+++ b/src/components/Team/TeamFormation.vue
@@ -489,15 +489,56 @@ watch(
     color: var(--text-secondary);
 }
 .hero-name {
-    font-size: 12px;
-    color: var(--text-secondary);
-    text-align: center;
-    min-width: 90px;
-    max-width: 140px;
-    white-space: nowrap;
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-align: center;
+  min-width: 90px;
+  max-width: 140px;
+  white-space: nowrap;
 }
 .empty-team {
-    color: var(--text-secondary);
-    font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 768px) {
+  .card-header {
+    flex-direction: column;
+    gap: var(--spacing-sm);
+    text-align: center;
+  }
+
+  .team-selector {
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+  }
+
+  .heroes-container {
+    padding: var(--spacing-sm);
+  }
+
+  .heroes-inline {
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    justify-content: center;
+  }
+
+  .hero-item {
+    min-width: 45px;
+  }
+
+  .hero-circle {
+    width: 40px;
+    height: 40px;
+  }
+
+  .hero-name {
+    font-size: 10px;
+    min-width: 0;
+    max-width: 60px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 </style>

--- a/src/layout/DefaultLayout.vue
+++ b/src/layout/DefaultLayout.vue
@@ -3,10 +3,15 @@
     <!-- 顶部导航 -->
     <nav class="dashboard-nav">
       <div class="nav-container">
-        <div class="nav-brand">
-          <img src="/icons/xiaoyugan.png" alt="XYZW" class="brand-logo">
+      <div class="nav-brand">
+        <img src="/icons/xiaoyugan.png" alt="XYZW" class="brand-logo">
+        <div class="brand-toggle" @click="isMobileMenuOpen = true">
+          <n-icon>
+            <Menu />
+          </n-icon>
           <span class="brand-text">XYZW 控制台</span>
         </div>
+      </div>
 
         <div class="nav-menu">
           <router-link to="/admin/dashboard" class="nav-item" active-class="active">
@@ -63,6 +68,34 @@
         </div>
       </div>
     </nav>
+    <n-drawer v-model:show="isMobileMenuOpen" placement="left" style="width: 260px">
+      <div class="drawer-menu">
+        <router-link to="/admin/dashboard" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><Home /></n-icon>
+          <span>首页</span>
+        </router-link>
+        <router-link to="/admin/game-features" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><Cube /></n-icon>
+          <span>游戏功能</span>
+        </router-link>
+        <router-link to="/tokens" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><PersonCircle /></n-icon>
+          <span>Token管理</span>
+        </router-link>
+        <router-link to="/admin/daily-tasks" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><Settings /></n-icon>
+          <span>任务管理</span>
+        </router-link>
+        <router-link to="/admin/message-test" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><ChatbubbleEllipsesSharp /></n-icon>
+          <span>消息测试</span>
+        </router-link>
+        <router-link to="/admin/profile" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><Settings /></n-icon>
+          <span>个人设置</span>
+        </router-link>
+      </div>
+    </n-drawer>
     <div class="main">
       <router-view />
     </div>
@@ -78,16 +111,20 @@ import {
   Cube,
   Settings,
   ChevronDown,
-  ChatbubbleEllipsesSharp
+  ChatbubbleEllipsesSharp,
+  Menu
 } from '@vicons/ionicons5'
 
 
 import { useRouter } from 'vue-router'
 import { useMessage } from 'naive-ui'
+import { ref } from 'vue'
 
 const tokenStore = useTokenStore()
 const router = useRouter()
 const message = useMessage()
+
+const isMobileMenuOpen = ref(false)
 
 const userMenuOptions = [
   {
@@ -148,13 +185,13 @@ const handleUserAction = (key) => {
 .nav-brand {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
+  gap: var(--spacing-xs);
   margin-right: var(--spacing-xl);
 }
 
 .brand-logo {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   border-radius: var(--border-radius-small);
 }
 
@@ -162,6 +199,18 @@ const handleUserAction = (key) => {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--text-primary);
+}
+
+.brand-toggle {
+  display: none;
+  align-items: center;
+  gap: var(--spacing-xs);
+  cursor: pointer;
+  font-size: var(--font-size-lg);
+}
+
+.brand-toggle .n-icon {
+  font-size: inherit;
 }
 
 .nav-menu {
@@ -215,5 +264,55 @@ const handleUserAction = (key) => {
 .username {
   font-weight: var(--font-weight-medium);
   color: var(--text-primary);
+}
+
+@media (max-width: 768px) {
+  .nav-item span {
+    display: none;
+  }
+
+  .nav-menu {
+    display: none;
+  }
+
+  .nav-item {
+    padding: var(--spacing-sm);
+    flex: 0 0 auto;
+  }
+
+  .nav-container {
+    height: 56px;
+  }
+
+  .brand-logo {
+    display: none;
+  }
+
+  .brand-toggle {
+    display: inline-flex;
+  }
+}
+
+
+.drawer-menu {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+}
+
+.drawer-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--border-radius-medium);
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.drawer-item.router-link-active {
+  background: var(--primary-color-light);
+  color: var(--primary-color);
 }
 </style>

--- a/src/views/DailyTasks.vue
+++ b/src/views/DailyTasks.vue
@@ -747,7 +747,7 @@ watch(() => gameRolesStore.selectedRole, (newRole) => {
 
 .tasks-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: var(--spacing-lg);
 }
 
@@ -760,9 +760,9 @@ watch(() => gameRolesStore.selectedRole, (newRole) => {
 }
 
 // 响应式设计
-@media (max-width: 1200px) {
+@media (max-width: 1024px) {
   .tasks-grid {
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 }
 

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -413,7 +413,7 @@ onMounted(async () => {
 
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: var(--spacing-lg);
 }
 
@@ -617,7 +617,7 @@ onMounted(async () => {
   }
 
   .stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 }
 

--- a/src/views/GameFeatures.vue
+++ b/src/views/GameFeatures.vue
@@ -295,7 +295,7 @@ watch(
 // 初始化游戏数据
 const initializeGameData = async () => {
   if (!tokenStore.selectedToken) return
-  
+
   try {
     const tokenId = tokenStore.selectedToken.id
     // 获取初始化数据（静默）
@@ -314,8 +314,9 @@ onUnmounted(() => {
 
 <style scoped lang="scss">
 .game-features-page {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  padding-bottom: calc(var(--spacing-md) + env(safe-area-inset-bottom));
 }
 
 /* 深色主题下背景 */
@@ -334,6 +335,16 @@ onUnmounted(() => {
   max-width: 1400px;
   margin: 0 auto;
   padding: 0 var(--spacing-lg);
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 0 var(--spacing-md);
+  }
+
+  .page-header {
+    display: none;
+  }
 }
 
 .header-content {
@@ -394,7 +405,7 @@ onUnmounted(() => {
 
 .features-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: var(--spacing-lg);
 }
 
@@ -592,7 +603,7 @@ onUnmounted(() => {
 // 响应式设计
 @media (max-width: 1024px) {
   .features-grid {
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 }
 

--- a/src/views/GameRoles.vue
+++ b/src/views/GameRoles.vue
@@ -391,9 +391,10 @@ onMounted(async () => {
 
 <style scoped lang="scss">
 .game-roles-page {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: var(--bg-secondary);
   padding: var(--spacing-xl) 0;
+  padding-bottom: calc(var(--spacing-md) + env(safe-area-inset-bottom));
 }
 
 .container {
@@ -430,7 +431,7 @@ onMounted(async () => {
 
 .roles-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: var(--spacing-lg);
 }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -13,6 +13,14 @@
             <span class="brand-text">XYZW 游戏管理系统</span>
           </div>
 
+          <div class="mobile-menu-button">
+            <n-button text @click="isMobileMenuOpen = true">
+              <n-icon>
+                <Menu />
+              </n-icon>
+            </n-button>
+          </div>
+
           <div class="nav-actions">
             <template v-if="!authStore.isAuthenticated">
               <n-button
@@ -44,6 +52,35 @@
         </div>
       </div>
     </nav>
+
+    <n-drawer v-model:show="isMobileMenuOpen" placement="left" style="width: 260px">
+      <div class="drawer-menu">
+        <router-link to="/" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><Ribbon /></n-icon>
+          <span>首页</span>
+        </router-link>
+        <router-link to="/admin/dashboard" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><Settings /></n-icon>
+          <span>控制台</span>
+        </router-link>
+        <router-link to="/admin/game-features" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><Cube /></n-icon>
+          <span>游戏功能</span>
+        </router-link>
+        <router-link to="/tokens" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><PersonCircle /></n-icon>
+          <span>Token管理</span>
+        </router-link>
+        <router-link to="/changelog" class="drawer-item" @click="isMobileMenuOpen = false">
+          <n-icon><Ribbon /></n-icon>
+          <span>更新日志</span>
+        </router-link>
+        <div class="drawer-actions">
+          <n-button type="primary" block @click="router.push('/login'); isMobileMenuOpen = false">登录</n-button>
+          <n-button type="primary" block @click="router.push('/register'); isMobileMenuOpen = false">注册</n-button>
+        </div>
+      </div>
+    </n-drawer>
 
     <!-- 主要内容 -->
     <main class="main-content">
@@ -209,12 +246,14 @@ import {
   PersonCircle,
   Cube,
   Ribbon,
-  Settings
+  Settings,
+  Menu
 } from '@vicons/ionicons5'
 
 const router = useRouter()
 const authStore = useAuthStore()
 const featuresSection = ref(null)
+const isMobileMenuOpen = ref(false)
 
 // 功能卡片数据
 const featureCards = ref([
@@ -291,10 +330,40 @@ onMounted(() => {
 
 <style scoped lang="scss">
 .home-page {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   position: relative;
   overflow-x: hidden;
+  padding-bottom: calc(var(--spacing-md) + env(safe-area-inset-bottom));
+}
+
+.drawer-menu {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+}
+
+.drawer-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--border-radius-medium);
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.drawer-item.router-link-active {
+  background: var(--primary-color-light);
+  color: var(--primary-color);
+}
+
+.drawer-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
 }
 
 // 导航栏
@@ -313,6 +382,10 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.mobile-menu-button {
+  display: none;
 }
 
 .nav-brand {
@@ -393,7 +466,7 @@ onMounted(() => {
 // 功能卡片
 .feature-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: var(--spacing-md);
 }
 
@@ -516,7 +589,7 @@ onMounted(() => {
 
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: var(--spacing-xl);
 }
 
@@ -591,6 +664,15 @@ onMounted(() => {
   .hero-content {
     grid-template-columns: 1fr;
     text-align: center;
+  }
+
+  .mobile-menu-button {
+    display: inline-flex;
+    margin-left: auto;
+  }
+
+  .nav-actions {
+    display: none;
   }
 
   .hero-title {

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -230,13 +230,14 @@ onMounted(() => {
 
 <style scoped lang="scss">
 .login-page {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
   overflow: hidden;
+  padding-bottom: calc(var(--spacing-md) + env(safe-area-inset-bottom));
 }
 
 /* 深色主题下背景 */

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -296,9 +296,10 @@ onMounted(() => {
 
 <style scoped lang="scss">
 .profile-page {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: var(--bg-secondary);
   padding: var(--spacing-xl) 0;
+  padding-bottom: calc(var(--spacing-md) + env(safe-area-inset-bottom));
 }
 
 .container {

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -198,12 +198,13 @@ const handleRegister = async () => {
 
 <style scoped lang="scss">
 .register-page {
-  min-height: 100vh;
+  min-height: 100dvh;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: var(--spacing-lg);
+  padding-bottom: calc(var(--spacing-md) + env(safe-area-inset-bottom));
 }
 
 /* 深色主题下背景 */

--- a/src/views/TokenImport/index.vue
+++ b/src/views/TokenImport/index.vue
@@ -1058,6 +1058,10 @@ onMounted(async () => {
 .header-actions {
   display: flex;
   gap: var(--spacing-md);
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  flex-wrap: nowrap;
 }
 
 .tokens-grid {


### PR DESCRIPTION
- 适配对话框组件（.arco-modal）在移动端的宽度与滚动
- /tokens 页 .header-actions 超出出现横向滚动
- 导航处将折叠图标与文字组合为可点击容器，图标在文字前，大小一致，点击打开侧边导航；仅在移动端显示该容器
- 修复身份卡片居中与容器宽度问题，优化资源区折叠/展开逻辑
- 优化部分页面在小屏下的布局与间距

fixes #61 