### PR TITLE
feat(俱乐部): 添加俱乐部申请列表管理功能

### DIFF
--- a/src/components/Club/ClubInfo.vue
+++ b/src/components/Club/ClubInfo.vue
@@ -20,9 +20,91 @@
       <div v-else>
         <div class="toolbar">
           <n-space size="small">
+            <!-- 申请列表按钮 -->
+            <n-button size="small" @click="getApplyList">申请列表</n-button>
             <n-button size="small" @click="refreshClub">刷新</n-button>
           </n-space>
         </div>
+        
+        <!-- 申请列表悬浮界面 -->
+        <n-modal
+          v-model:show="showApplyList"
+          title="俱乐部申请列表"
+          :mask-closable="true"
+          :show-close-button="true"
+          :close-on-esc="true"
+          preset="card"
+          :show-footer="false"
+          :style="{ width: '700px' }"
+        >
+          <template #header-extra>
+            <n-space size="small">
+              <n-button 
+                size="small" 
+                type="primary" 
+                @click="approveAll" 
+                :disabled="applyList.length === 0"
+              >
+                一键通过
+              </n-button>
+              <n-button 
+                size="small" 
+                type="error" 
+                @click="rejectAll" 
+                :disabled="applyList.length === 0"
+              >
+                一键拒绝
+              </n-button>
+            </n-space>
+          </template>
+          <div v-if="loadingApply" class="loading">
+            <n-spin size="small" />
+            <span style="margin-left: 8px;">正在加载申请列表...</span>
+          </div>
+          <div v-else-if="applyList.length === 0" class="empty-apply">
+            <n-empty description="暂无申请" />
+          </div>
+          <div v-else class="apply-list-container">
+            <div class="apply-list" :style="{ maxHeight: '800px', overflowY: 'auto' }">
+              <div 
+                v-for="apply in applyList" 
+                :key="apply.roleId" 
+                class="apply-item"
+                :class="{ 'apply-item-hover': hoveredItemId === apply.roleId }"
+                @mouseenter="hoveredItemId = apply.roleId"
+                @mouseleave="hoveredItemId = null"
+              >
+                <div class="apply-left">
+                  <n-avatar
+                    :size="28"
+                    :src="apply.headImg || '/icons/xiaoyugan.png'"
+                  />
+                  <div class="apply-info">
+                    <div class="apply-name">{{ apply.name }}(ID:{{ apply.roleId }})</div>
+                    <div class="apply-details">
+                      <span>等级: {{ apply.level || 0 }}</span>
+                      <span class="apply-power">{{ formatNumber(apply.power || 0) }}</span>
+                      <span v-if="apply.serverId">服务区: {{ apply.serverId }}</span>
+                    </div>
+                    <div v-if="apply.applyReason" class="apply-reason">
+                      申请留言: {{ apply.applyReason }}
+                    </div>
+                  </div>
+                </div>
+                <div class="apply-right">
+                  <n-space size="small">
+                    <n-button size="tiny" type="primary" @click="approveApply(apply.roleId)">
+                      通过
+                    </n-button>
+                    <n-button size="tiny" @click="rejectApply(apply.roleId)">
+                      拒绝
+                    </n-button>
+                  </n-space>
+                </div>
+              </div>
+            </div>
+          </div>
+        </n-modal>
 
         <n-tabs v-model:value="activeTab" type="line" animated>
           <n-tab-pane name="overview" tab="概览" display-directive="show:lazy">
@@ -108,6 +190,15 @@
                       redQuenchlabel(m.custom?.red_quench_cnt || 0)
                     }}</span>
                     <span class="tag">{{ jobLabel(m.job) }}</span>
+                    <!-- 踢出按钮，只有会长或副会长可以看到 -->
+                    <n-button
+                      v-if="canKick && m.job !== 1"
+                      size="tiny"
+                      type="error"
+                      @click="kickMember(m.roleId)"
+                    >
+                      踢出
+                    </n-button>
                   </div>
                 </div>
               </div>
@@ -136,7 +227,7 @@
             display-directive="show:lazy"
           >
             <ClubWeirdTowerInfo inline />
-          </n-tab-pane>=
+          </n-tab-pane>
           
           <n-tab-pane
             name="carsocre"
@@ -144,7 +235,7 @@
             display-directive="show:lazy"
           >
             <CarScoreInfo inline />
-          </n-tab-pane>=
+          </n-tab-pane>
         </n-tabs>
       </div>
     </template>
@@ -152,13 +243,14 @@
 </template>
 
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useMessage } from "naive-ui";
 import { useTokenStore } from "@/stores/tokenStore";
 import ClubBattleRecords from "./ClubBattleRecords.vue";
 import ClubHistoryRecords from "./ClubHistoryRecords.vue";
 import ClubWeirdTowerInfo from './ClubWeirdTowerInfo.vue';
-import CarScoreInfo from './CarScoreInfo.vue'
+import CarScoreInfo from './CarScoreInfo.vue';
+import { $emit } from '@/stores/events'
 
 const tokenStore = useTokenStore();
 const message = useMessage();
@@ -186,7 +278,228 @@ const topMembers = computed(() => {
     .slice(0, 30);
 });
 
+// 获取当前角色在俱乐部中的职位
+const currentMemberJob = computed(() => {
+  const roleId = tokenStore.gameData?.roleInfo?.role?.roleId;
+  if (!roleId) return 0;
+  const currentMember = members.value.find(m => Number(m.roleId) === Number(roleId));
+  return currentMember?.job || 0;
+});
+
+// 检查是否有踢人权限（会长或副会长）
+const canKick = computed(() => {
+  return [1, 2].includes(currentMemberJob.value);
+});
+
+// 踢出成员
+const kickMember = (roleId) => {
+  const token = tokenStore.selectedToken;
+  if (!token) return;
+  
+  // 正确的发送方式：第一个参数是命令名称，第二个参数是命令体
+  tokenStore.sendMessage(token.id, "legion_kickout", {
+    roleId: Number(roleId)
+  });
+  
+  // 乐观更新：立即从本地成员列表中移除该成员
+  if (tokenStore.gameData?.legionInfo?.info?.members) {
+    // 删除成员信息
+    delete tokenStore.gameData.legionInfo.info.members[roleId];
+    // 刷新俱乐部信息以确保数据同步
+    setTimeout(() => {
+      refreshClub();
+    }, 1000);
+  }
+  
+  message.info(`正在踢出成员 ID: ${roleId}`);
+};
+
+// 获取申请列表
+const getApplyList = () => {
+  const token = tokenStore.selectedToken;
+  if (!token) return;
+  
+  // 显示申请列表界面
+  showApplyList.value = true;
+  // 设置加载状态
+  loadingApply.value = true;
+  applyList.value = [];
+  
+  // 发送legion_applylist命令
+  tokenStore.sendMessage(token.id, "legion_applylist", {});
+  message.info("正在获取申请列表");
+};
+
+// 通过申请
+const approveApply = (roleId) => {
+  const token = tokenStore.selectedToken;
+  if (!token) return;
+  
+  // 发送通过申请命令
+  tokenStore.sendMessage(token.id, "legion_agree", {
+    roleId: Number(roleId)
+  });
+  
+  // 从申请列表中移除该成员
+  applyList.value = applyList.value.filter(apply => apply.roleId !== roleId);
+  message.info(`已通过成员 ID: ${roleId} 的申请`);
+};
+
+// 拒绝申请
+const rejectApply = (roleId) => {
+  const token = tokenStore.selectedToken;
+  if (!token) return;
+  
+  // 发送拒绝申请命令
+  tokenStore.sendMessage(token.id, "legion_ignore", {
+    roleId: Number(roleId)
+  });
+  
+  // 从申请列表中移除该成员
+  applyList.value = applyList.value.filter(apply => apply.roleId !== roleId);
+  message.info(`已拒绝成员 ID: ${roleId} 的申请`);
+};
+
+// 一键通过所有申请
+const approveAll = () => {
+  const token = tokenStore.selectedToken;
+  if (!token) return;
+  
+  const count = applyList.value.length;
+  if (count === 0) return;
+  
+  // 遍历所有申请项，发送通过命令
+  applyList.value.forEach(apply => {
+    tokenStore.sendMessage(token.id, "legion_agree", {
+      roleId: Number(apply.roleId)
+    });
+  });
+  
+  // 清空申请列表
+  applyList.value = [];
+  message.success(`已通过所有 ${count} 个申请`);
+};
+
+// 一键拒绝所有申请
+const rejectAll = () => {
+  const token = tokenStore.selectedToken;
+  if (!token) return;
+  
+  const count = applyList.value.length;
+  if (count === 0) return;
+  
+  // 遍历所有申请项，发送拒绝命令
+  applyList.value.forEach(apply => {
+    tokenStore.sendMessage(token.id, "legion_ignore", {
+      roleId: Number(apply.roleId)
+    });
+  });
+  
+  // 清空申请列表
+  applyList.value = [];
+  message.success(`已拒绝所有 ${count} 个申请`);
+};
+
+
+
 const activeTab = ref("overview");
+
+// 申请列表状态
+const showApplyList = ref(false);
+const loadingApply = ref(false);
+const applyList = ref([]);
+
+// 选择状态
+const hoveredItemId = ref(null);
+
+// 处理申请列表响应
+const handleApplyListResp = (session) => {
+  // 从session对象中提取响应内容
+  const responseBody = session.body;
+  
+  if (responseBody) {
+    if (typeof responseBody === 'object') {
+      // 处理对象类型的响应
+      
+      // 检查是否有roleList数组字段（根据用户要求）
+      if (Array.isArray(responseBody.roleList)) {
+        // 从roleList数组中提取申请列表数据
+        // 过滤掉无效的申请项（没有roleId的项）
+        const validRoles = responseBody.roleList.filter(role => role.roleId && role.name);
+        applyList.value = validRoles.map(role => ({
+          headImg: role.headImg,
+          level: role.level,
+          name: role.name,
+          power: role.power,
+          roleId: role.roleId,
+          serverId: role.ext?.['server_id'] || '',
+          applyReason: role.ext?.['legion_apply_reason'] || ''
+        }));
+        // 停止加载状态
+        loadingApply.value = false;
+        message.success(`获取到 ${validRoles.length} 个申请`);
+      } else if (Array.isArray(responseBody.applyList) || Array.isArray(responseBody.list) || Array.isArray(responseBody.data)) {
+        // 兼容其他可能的数组字段
+        const applyArray = responseBody.applyList || responseBody.list || responseBody.data;
+        // 过滤掉无效的申请项，并提取服务区和申请留言信息
+        applyList.value = applyArray.filter(apply => apply.roleId && apply.name).map(apply => ({
+          ...apply,
+          serverId: apply.ext?.['server_id'] || '',
+          applyReason: apply.ext?.['legion_apply_reason'] || ''
+        }));
+        loadingApply.value = false;
+        message.success(`获取到 ${applyList.value.length} 个申请`);
+      } else if (Array.isArray(responseBody)) {
+        // 直接是数组的情况
+        // 过滤掉无效的申请项，并提取服务区和申请留言信息
+        applyList.value = responseBody.filter(apply => apply.roleId && apply.name).map(apply => ({
+          ...apply,
+          serverId: apply.ext?.['server_id'] || '',
+          applyReason: apply.ext?.['legion_apply_reason'] || ''
+        }));
+        loadingApply.value = false;
+        message.success(`获取到 ${applyList.value.length} 个申请`);
+      } else {
+        // 没有有效的申请数据，设置为空数组
+        applyList.value = [];
+        loadingApply.value = false;
+        message.info("暂无申请");
+      }
+    } else if (Array.isArray(responseBody)) {
+      // 直接是数组的情况
+      // 过滤掉无效的申请项，并提取服务区和申请留言信息
+      applyList.value = responseBody.filter(apply => apply.roleId && apply.name).map(apply => ({
+        ...apply,
+        serverId: apply.ext?.['server_id'] || '',
+        applyReason: apply.ext?.['legion_apply_reason'] || ''
+      }));
+      loadingApply.value = false;
+      message.success(`获取到 ${applyList.value.length} 个申请`);
+    } else {
+      // 处理其他类型的响应
+      applyList.value = [];
+      loadingApply.value = false;
+      message.info("暂无申请");
+    }
+  } else {
+    // 没有申请数据或格式不正确
+    applyList.value = [];
+    loadingApply.value = false;
+    message.info("暂无申请");
+  }
+};
+
+// 组件挂载时添加事件监听器
+onMounted(() => {
+  // 监听申请列表响应事件（使用小写，与tokenStore保持一致）
+  $emit.on("legion_applylistresp", handleApplyListResp);
+});
+
+// 组件卸载时移除事件监听器
+onUnmounted(() => {
+  // 移除申请列表响应事件监听（使用小写，与tokenStore保持一致）
+  $emit.off("legion_applylistresp", handleApplyListResp);
+});
 
 // 今日是否已进行俱乐部签到
 const legionSignedIn = computed(() => {
@@ -457,4 +770,144 @@ const formatNumber = (num) => {
   border-radius: 50%;
   background: currentColor;
 }
+
+/* 申请列表样式 */
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.empty-apply {
+  padding: 30px 0;
+}
+
+.apply-list-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.apply-list {
+  max-height: 200px;
+  overflow-y: auto;
+  padding-right: 8px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+}
+
+.apply-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  margin: 0;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.apply-item:last-child {
+  border-bottom: none;
+}
+
+/* 悬停效果 */
+.apply-item-hover {
+  background: var(--bg-tertiary);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* 选中状态 */
+.apply-item-selected {
+  background: var(--primary-color-light);
+  border-left: 3px solid var(--primary-color);
+}
+
+.apply-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.apply-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.apply-name {
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+}
+
+.apply-details {
+  display: flex;
+  gap: 12px;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.apply-power {
+  font-feature-settings: "tnum" 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.apply-reason {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  margin-top: 4px;
+  word-break: break-word;
+  white-space: normal;
+  line-height: 1.4;
+}
+
+.apply-right {
+  display: flex;
+  gap: 8px;
+}
+
+/* 批量操作栏样式 */
+.apply-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--bg-tertiary);
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+}
+
+.selected-info {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin-left: auto;
+}
+
+/* 滚动条样式 */
+.apply-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.apply-list::-webkit-scrollbar-track {
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+}
+
+.apply-list::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 3px;
+}
+
+.apply-list::-webkit-scrollbar-thumb:hover {
+  background: var(--text-tertiary);
+}
+
+
 </style>

--- a/src/stores/events/index.ts
+++ b/src/stores/events/index.ts
@@ -22,11 +22,10 @@ export const emitPlus = (
   event: string | symbol,
   ...args: Array<any>
 ): boolean => {
-  if (events.has(event as string)) {
-    return $emit.emit(event, ...args);
-  } else {
-    return $emit.emit("$any", event, ...args);
-  }
+  // 先触发具体事件，然后触发$any事件
+  const result = $emit.emit(event, ...args);
+  $emit.emit("$any", event, ...args);
+  return result;
 };
 
 export interface Session {
@@ -56,6 +55,11 @@ StudyPlugin({
 });
 
 onSome(["_sys/ack"], (data: Session) => {});
+
+// 俱乐部申请列表响应
+onSome(["legion_applylistresp"], (data: Session) => {
+  gameLogger.debug(`收到俱乐部申请列表响应: ${data.tokenId}`, data.body);
+});
 
 // omail_newmailnotify   邮件
 

--- a/src/utils/xyzwWebSocket.js
+++ b/src/utils/xyzwWebSocket.js
@@ -149,8 +149,13 @@ export function registerDefaultCommands(reg) {
     .register("legion_getwarrank")
     .register("legionwar_getdetails")
     .register("legion_storebuygoods")
+    .register("legion_kickout")
+    .register("legion_applylist")
+    .register("legion_approveapply")
+    .register("legion_refuseapply")
+    .register("legion_agree")
+    .register("legion_ignore")
 
-    //盐场
     .register("legion_getinfobyid")
     .register("legion_getarearank")
     .register("saltroad_getsaltroadwartotalrank")
@@ -890,6 +895,10 @@ export class XyzwWebSocketClient {
           1300050: "请修改您的采购次数",
           200020: "出了点小问题，请尝试重启游戏解决～",
           200160: "模块未开启",
+          2300190: "未加入俱乐部",
+          2300370: "俱乐部商品购买数量超出上限",
+          400000: "物品不存在",
+          2300070: "未加入俱乐部",
           3500020: "没有可领取的奖励"
         };
         
@@ -1026,6 +1035,7 @@ export class XyzwWebSocketClient {
           1300050: "请修改您的采购次数",
           200020: "出了点小问题，请尝试重启游戏解决～",
           200160: "模块未开启",
+          2300190: "未加入俱乐部",
           3500020: "没有可领取的奖励"
         };
         


### PR DESCRIPTION
- 在ClubInfo组件中添加申请列表弹窗及相关操作功能
- 实现申请列表的获取、显示、单个/批量通过/拒绝功能
- 添加踢出成员功能，仅限会长和副会长使用
- 在xyzwWebSocket中注册相关俱乐部命令
- 在events模块优化事件触发逻辑
- 在tokenStore中添加重试机制获取角色信息