### PR TITLE
优化批量消耗与怪异塔爬塔次数配置

### DIFF
--- a/src/components/Tower/WeirdTowerStatus.vue
+++ b/src/components/Tower/WeirdTowerStatus.vue
@@ -24,19 +24,31 @@
     </div>
 
     <div class="card-actions">
-      <button
-        :class="[
-          'climb-button',
-          {
-            active: canClimb,
-            disabled: !canClimb,
-          },
-        ]"
-        :disabled="!canClimb"
-        @click="startTowerClimb"
-      >
-        {{ isClimbing.value ? "爬塔中..." : "开始爬塔" }}
-      </button>
+      <div class="climb-action-row">
+        <input
+          v-model.number="maxClimbInput"
+          class="climb-limit-input"
+          type="number"
+          min="1"
+          step="1"
+          aria-label="怪异塔爬塔次数"
+          :disabled="isClimbing || isUsingItems || isMerging"
+        />
+        <span class="climb-limit-unit">次</span>
+        <button
+          :class="[
+            'climb-button',
+            {
+              active: canClimb,
+              disabled: !canClimb,
+            },
+          ]"
+          :disabled="!canClimb"
+          @click="startTowerClimb"
+        >
+          {{ isClimbing ? "爬塔中..." : "开始爬塔" }}
+        </button>
+      </div>
 
       <!-- 停止批量爬塔按钮，仅批量时显示 -->
       <button v-if="isClimbing" class="stop-button" @click="stopClimbing">停止爬塔</button>
@@ -90,6 +102,10 @@ const stopUsingItems = () => {
 import { computed, onMounted, ref, watch } from "vue";
 import { useTokenStore } from "@/stores/tokenStore";
 import { useMessage } from "naive-ui";
+import {
+  DEFAULT_WEIRD_TOWER_MAX_CLIMB,
+  normalizeWeirdTowerMaxClimb,
+} from "@/utils/towerClimbLimit.js";
 
 const tokenStore = useTokenStore();
 const message = useMessage();
@@ -98,6 +114,7 @@ const message = useMessage();
 const isClimbing = ref(false);
 const isUsingItems = ref(false);
 const isMerging = ref(false);
+const maxClimbInput = ref(DEFAULT_WEIRD_TOWER_MAX_CLIMB);
 const climbTimeout = ref(null); // 用于超时重置状态
 const itemTimeout = ref(null); // 用于道具使用超时
 const mergeTimeout = ref(null); // 用于合成超时
@@ -473,7 +490,8 @@ const startTowerClimb = async () => {
   isClimbing.value = true;
   stopFlag = false;
   let climbCount = 0;
-  let maxClimb = 100; // 最多批量次数，防止死循环
+  const maxClimb = normalizeWeirdTowerMaxClimb(maxClimbInput.value);
+  maxClimbInput.value = maxClimb;
   // 设置超时保护，60秒后自动重置状态
   climbTimeout.value = setTimeout(() => {
     isClimbing.value = false;
@@ -773,6 +791,52 @@ onMounted(() => {
   gap: var(--spacing-sm);
   margin-top: auto;
   padding-top: var(--spacing-sm);
+}
+
+.climb-action-row {
+  display: flex;
+  align-items: stretch;
+  gap: var(--spacing-sm);
+  width: 100%;
+
+  .climb-button {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+.climb-limit-input {
+  flex: 0 0 86px;
+  width: 86px;
+  padding: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  text-align: center;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: var(--border-radius-medium);
+  outline: none;
+  transition: border-color var(--transition-fast);
+
+  &:focus {
+    border-color: #8b5cf6;
+  }
+
+  &:disabled {
+    color: var(--text-tertiary);
+    cursor: not-allowed;
+    background: var(--bg-secondary);
+  }
+}
+
+.climb-limit-unit {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
 }
 
 .climb-button {

--- a/src/components/cards/BoxHelperCard.vue
+++ b/src/components/cards/BoxHelperCard.vue
@@ -16,7 +16,12 @@
       </div>
       <div class="container">
         <div class="list">
-          <div class="item" v-for="item in boxDataList" :key="item.type">
+          <div
+            class="item"
+            v-for="item in boxDataList"
+            :key="item.type"
+            :data-testid="`box-count-${item.itemId}`"
+          >
             <img :src="item.img" :alt="item.type" />
             <div class="box-info">
               <div class="box-type">{{ item.type }}</div>
@@ -25,8 +30,18 @@
           </div>
         </div>
         <div class="selects">
-          <n-select v-model:value="type" :options="typeOptions" />
-          <n-select v-model:value="number" :options="numberOptions" />
+          <n-select
+            v-model:value="type"
+            :options="typeOptions"
+            :disabled="state.isRunning"
+            data-testid="box-type-select"
+          />
+          <n-select
+            v-model:value="number"
+            :options="numberOptions"
+            :disabled="state.isRunning"
+            data-testid="box-number-select"
+          />
         </div>
       </div>
     </template>
@@ -37,21 +52,35 @@
         secondary
         size="small"
         block
+        data-testid="box-open-button"
         @click="handleBoxHelper"
       >
         {{ state.isRunning ? "运行中" : "开启宝箱" }}
       </a-button>
-      <a-button type="primary" size="small" @click="batchclaimboxpointreward"
-        >领取宝箱积分</a-button
+      <a-button
+        type="primary"
+        size="small"
+        :disabled="state.isRunning"
+        data-testid="box-claim-points-button"
+        @click="batchclaimboxpointreward"
       >
+        {{ claimBoxPointButtonText }}
+      </a-button>
     </template>
   </MyCard>
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted, watchEffect } from "vue";
+import { ref, computed } from "vue";
 import { useMessage } from "naive-ui";
 import { useTokenStore } from "@/stores/tokenStore";
+import {
+  HELPER_BATCH_DELAY_MS,
+  HELPER_COMMAND_TIMEOUT_MS,
+  getClaimableBoxPoints,
+  getErrorMessage,
+  runInventoryVerifiedGameCommand,
+} from "@/utils/helperTaskRunner";
 import MyCard from "../Common/MyCard.vue";
 
 const tokenStore = useTokenStore();
@@ -67,21 +96,25 @@ const boxDataList = computed(() => {
   return [
     {
       type: "木质宝箱",
+      itemId: 2001,
       img: getImgPath("/box/mzbx.png"),
       count: roleInfo.value?.role?.items?.[2001]?.quantity || 0,
     },
     {
       type: "青铜宝箱",
+      itemId: 2002,
       img: getImgPath("/box/qtbx.png"),
       count: roleInfo.value?.role?.items?.[2002]?.quantity || 0,
     },
     {
       type: "黄金宝箱",
+      itemId: 2003,
       img: getImgPath("/box/hjbx.png"),
       count: roleInfo.value?.role?.items?.[2003]?.quantity || 0,
     },
     {
       type: "铂金宝箱",
+      itemId: 2004,
       img: getImgPath("/box/bjbx.png"),
       count: roleInfo.value?.role?.items?.[2004]?.quantity || 0,
     },
@@ -96,6 +129,13 @@ const totalPoints = computed(() => {
 
   return wooden * 1 + bronze * 10 + gold * 20 + platinum * 50;
 });
+
+const claimableBoxPoints = computed(() => getClaimableBoxPoints(roleInfo.value));
+const claimBoxPointButtonText = computed(() =>
+  claimableBoxPoints.value > 1000
+    ? `领取${claimableBoxPoints.value}宝箱积分`
+    : "领取宝箱积分",
+);
 
 const type = ref(2001);
 const typeOptions = [
@@ -132,38 +172,43 @@ const batchclaimboxpointreward = async () => {
 };
 
 const handleBoxHelper = async () => {
+  if (state.value.isRunning) {
+    return;
+  }
+
   if (!tokenStore.selectedToken) {
     message.warning("请先选择Token");
     return;
   }
+
   const tokenId = tokenStore.selectedToken.id;
+  const selectedType = type.value;
+  const selectedNumber = number.value;
+
   state.value.isRunning = true;
   message.info("宝箱开启中");
-  if (number.value >= 10) {
-    const batches = Math.floor(number.value / 10);
-    const remainder = number.value % 10;
-    for (let i = 0; i < batches; i++) {
-      const result = await tokenStore.sendMessageWithPromise(
-        tokenId,
-        "item_openbox",
-        { itemId: type.value, number: 10 },
-      );
-    }
-    if (remainder > 0) {
-      const result = await tokenStore.sendMessageWithPromise(
-        tokenId,
-        "item_openbox",
-        { itemId: type.value, number: remainder },
-      );
-    }
-    await tokenStore.sendMessage(tokenId, "item_batchclaimboxpointreward");
-    await new Promise((r) => setTimeout(r, 500));
+
+  try {
+    await runInventoryVerifiedGameCommand({
+      tokenStore,
+      tokenId,
+      cmd: "item_openbox",
+      itemId: selectedType,
+      total: selectedNumber,
+      timeout: HELPER_COMMAND_TIMEOUT_MS,
+      delayMs: HELPER_BATCH_DELAY_MS,
+      createParams: (amount) => ({ itemId: selectedType, number: amount }),
+      queryInventory: () => tokenStore.sendGetRoleInfo(tokenId),
+    });
+
     await tokenStore.sendMessage(tokenId, "role_getroleinfo");
     // 更新活动进度
     tokenStore.sendMessage(tokenId, "activity_get");
     message.success("宝箱开启完毕");
+  } catch (error) {
+    message.error(`宝箱开启失败：${getErrorMessage(error)}`);
+  } finally {
     state.value.isRunning = false;
-    return;
   }
 };
 </script>

--- a/src/components/cards/RecruitHelperCard.vue
+++ b/src/components/cards/RecruitHelperCard.vue
@@ -12,7 +12,12 @@
     <template #default>
       <div class="container">
         <div class="list">
-          <div class="item" v-for="item in dataList" :key="item.type">
+          <div
+            class="item"
+            v-for="item in dataList"
+            :key="item.type"
+            :data-testid="`recruit-count-${item.itemId}`"
+          >
             <img :src="item.img" :alt="item.type" />
             <div class="box-info">
               <div class="box-type">{{ item.type }}</div>
@@ -21,7 +26,12 @@
           </div>
         </div>
         <div class="selects">
-          <n-select v-model:value="number" :options="numberOptions" />
+          <n-select
+            v-model:value="number"
+            :options="numberOptions"
+            :disabled="state.isRunning"
+            data-testid="recruit-number-select"
+          />
         </div>
       </div>
     </template>
@@ -32,6 +42,7 @@
         secondary
         size="small"
         block
+        data-testid="recruit-start-button"
         @click="handleHelper"
       >
         {{ state.isRunning ? "运行中" : "开始招募" }}
@@ -41,9 +52,15 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted, watchEffect } from "vue";
+import { ref, computed } from "vue";
 import { useMessage } from "naive-ui";
 import { useTokenStore } from "@/stores/tokenStore";
+import {
+  HELPER_BATCH_DELAY_MS,
+  HELPER_COMMAND_TIMEOUT_MS,
+  getErrorMessage,
+  runInventoryVerifiedGameCommand,
+} from "@/utils/helperTaskRunner";
 import MyCard from "../Common/MyCard.vue";
 
 const tokenStore = useTokenStore();
@@ -59,6 +76,7 @@ const dataList = computed(() => {
   return [
     {
       type: "招募令",
+      itemId: 1001,
       img: getImgPath("/icons/zml.png"),
       count: roleInfo.value?.role?.items?.[1001]?.quantity || 0,
     },
@@ -79,36 +97,42 @@ const state = ref({
 });
 
 const handleHelper = async () => {
+  if (state.value.isRunning) {
+    return;
+  }
+
   if (!tokenStore.selectedToken) {
     message.warning("请先选择Token");
     return;
   }
+
   const tokenId = tokenStore.selectedToken.id;
+  const selectedNumber = number.value;
+
   state.value.isRunning = true;
   message.info("招募助手运行中");
-  if (number.value >= 10) {
-    const batches = Math.floor(number.value / 10);
-    const remainder = number.value % 10;
-    for (let i = 0; i < batches; i++) {
-      const result = await tokenStore.sendMessageWithPromise(
-        tokenId,
-        "hero_recruit",
-        { recruitType: 1, recruitNumber: 10 },
-      );
-    }
-    if (remainder > 0) {
-      const result = await tokenStore.sendMessageWithPromise(
-        tokenId,
-        "hero_recruit",
-        { recruitType: 1, recruitNumber: remainder },
-      );
-    }
+
+  try {
+    await runInventoryVerifiedGameCommand({
+      tokenStore,
+      tokenId,
+      cmd: "hero_recruit",
+      itemId: 1001,
+      total: selectedNumber,
+      timeout: HELPER_COMMAND_TIMEOUT_MS,
+      delayMs: HELPER_BATCH_DELAY_MS,
+      createParams: (amount) => ({ recruitType: 1, recruitNumber: amount }),
+      queryInventory: () => tokenStore.sendGetRoleInfo(tokenId),
+    });
+
     await tokenStore.sendMessage(tokenId, "role_getroleinfo");
     // 更新活动进度
     tokenStore.sendMessage(tokenId, "activity_get");
     message.success("招募完毕");
+  } catch (error) {
+    message.error(`招募失败：${getErrorMessage(error)}`);
+  } finally {
     state.value.isRunning = false;
-    return;
   }
 };
 </script>

--- a/src/utils/batch/tasksTower.js
+++ b/src/utils/batch/tasksTower.js
@@ -2,6 +2,7 @@
  * 爬塔类任务
  * 包含: climbTower, climbWeirdTower, batchClaimFreeEnergy
  */
+import { normalizeWeirdTowerMaxClimb } from "../towerClimbLimit.js";
 
 /**
  * 创建爬塔类任务执行器
@@ -25,6 +26,7 @@ export function createTasksTower(deps) {
     currentRunningTokenId,
     currentSettings,
     loadSettings,
+    weirdTowerMaxClimb,
   } = deps;
 
   /**
@@ -359,8 +361,16 @@ export function createTasksTower(deps) {
         });
 
         let count = 0;
-        const MAX_CLIMB = 100;
+        const MAX_CLIMB = normalizeWeirdTowerMaxClimb(
+          weirdTowerMaxClimb?.value ?? weirdTowerMaxClimb,
+        );
         let consecutiveFailures = 0;
+
+        addLog({
+          time: new Date().toLocaleTimeString(),
+          message: `${token.name} 本次最多爬怪异塔 ${MAX_CLIMB} 次`,
+          type: "info",
+        });
 
         while (currentEnergy > 0 && count < MAX_CLIMB && !shouldStop.value) {
           try {

--- a/src/utils/helperTaskRunner.js
+++ b/src/utils/helperTaskRunner.js
@@ -1,0 +1,318 @@
+export const HELPER_BATCH_SIZE = 10;
+export const HELPER_BATCH_DELAY_MS = 300;
+export const HELPER_COMMAND_TIMEOUT_MS = 5000;
+export const HELPER_RETRY_DELAY_MS = 1000;
+export const HELPER_MAX_RETRIES = 2;
+
+export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export function buildTenBatchPlan(total, batchSize = HELPER_BATCH_SIZE) {
+  const safeTotal = Math.max(0, Math.trunc(Number(total) || 0));
+  const safeBatchSize = Math.max(
+    1,
+    Math.trunc(Number(batchSize) || HELPER_BATCH_SIZE),
+  );
+  const fullBatches = Math.floor(safeTotal / safeBatchSize);
+  const remainder = safeTotal % safeBatchSize;
+  const plan = Array.from({ length: fullBatches }, () => safeBatchSize);
+
+  if (remainder > 0) {
+    plan.push(remainder);
+  }
+
+  return plan;
+}
+
+export function getErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error || "未知错误");
+}
+
+export function isRateLimitError(error) {
+  const message = getErrorMessage(error);
+
+  return message.includes("400312") || message.includes("操作过快");
+}
+
+export function getItemQuantity(roleInfo, itemId) {
+  const item =
+    roleInfo?.role?.items?.[itemId] ??
+    roleInfo?.role?.items?.[String(itemId)] ??
+    roleInfo?.items?.[itemId] ??
+    roleInfo?.items?.[String(itemId)];
+
+  const quantity = item?.quantity ?? item?.count ?? 0;
+  const numericQuantity = Number(quantity);
+
+  return Number.isFinite(numericQuantity) ? numericQuantity : 0;
+}
+
+function toFiniteNumber(value) {
+  if (typeof value === "string") {
+    value = value.replace(/,/g, "").trim();
+  }
+
+  const number = Number(value);
+
+  return Number.isFinite(number) ? number : null;
+}
+
+function pickNumericLeaf(value) {
+  const directNumber = toFiniteNumber(value);
+
+  if (directNumber !== null) {
+    return directNumber;
+  }
+
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const preferredKeys = [
+    "canClaim",
+    "claimable",
+    "available",
+    "value",
+    "amount",
+    "quantity",
+    "count",
+    "num",
+    "points",
+    "score",
+  ];
+
+  for (const key of preferredKeys) {
+    const number = toFiniteNumber(value[key]);
+
+    if (number !== null) {
+      return number;
+    }
+  }
+
+  return null;
+}
+
+export function getClaimableBoxPoints(roleInfo) {
+  const candidates = [
+    roleInfo?.role?.boxPoint,
+    roleInfo?.role?.boxPoints,
+    roleInfo?.role?.box_point,
+    roleInfo?.role?.box_points,
+    roleInfo?.role?.boxPointReward,
+    roleInfo?.role?.boxPointRewards,
+    roleInfo?.role?.box_point_reward,
+    roleInfo?.data?.role?.boxPoint,
+    roleInfo?.data?.role?.boxPoints,
+    roleInfo?.data?.role?.box_point,
+    roleInfo?.data?.role?.box_points,
+    roleInfo?.data?.role?.boxPointReward,
+    roleInfo?.data?.role?.boxPointRewards,
+    roleInfo?.data?.role?.box_point_reward,
+    roleInfo?.boxPoint,
+    roleInfo?.boxPoints,
+    roleInfo?.box_point,
+    roleInfo?.box_points,
+    roleInfo?.boxPointReward,
+    roleInfo?.boxPointRewards,
+    roleInfo?.box_point_reward,
+  ];
+
+  for (const candidate of candidates) {
+    const number = pickNumericLeaf(candidate);
+
+    if (number !== null) {
+      return Math.max(0, Math.trunc(number));
+    }
+  }
+
+  const matches = [];
+  const seen = new Set();
+  const scan = (value, path = "", depth = 0) => {
+    if (!value || typeof value !== "object" || depth > 5 || seen.has(value)) {
+      return;
+    }
+
+    seen.add(value);
+
+    for (const [key, child] of Object.entries(value)) {
+      const nextPath = path ? `${path}.${key}` : key;
+
+      if (/box[_-]?points?|box.*point|point.*box/i.test(key)) {
+        const number = pickNumericLeaf(child);
+
+        if (number !== null) {
+          matches.push({ path: nextPath, number });
+        }
+      }
+
+      scan(child, nextPath, depth + 1);
+    }
+  };
+
+  scan(roleInfo);
+
+  if (matches.length === 0) {
+    return 0;
+  }
+
+  matches.sort((left, right) => {
+    const leftClaimScore = /claim|available|reward/i.test(left.path) ? 1 : 0;
+    const rightClaimScore = /claim|available|reward/i.test(right.path) ? 1 : 0;
+
+    return rightClaimScore - leftClaimScore;
+  });
+
+  return Math.max(0, Math.trunc(matches[0].number));
+}
+
+export async function runBatchedGameCommand({
+  tokenStore,
+  tokenId,
+  cmd,
+  total,
+  createParams,
+  batchSize = HELPER_BATCH_SIZE,
+  timeout = HELPER_COMMAND_TIMEOUT_MS,
+  delayMs = HELPER_BATCH_DELAY_MS,
+  retryDelayMs = HELPER_RETRY_DELAY_MS,
+  maxRetries = HELPER_MAX_RETRIES,
+  sleepFn = sleep,
+  onProgress,
+}) {
+  const plan = buildTenBatchPlan(total, batchSize);
+  let completed = 0;
+
+  for (const [index, batchAmount] of plan.entries()) {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await tokenStore.sendMessageWithPromise(
+          tokenId,
+          cmd,
+          createParams(batchAmount),
+          timeout,
+        );
+        break;
+      } catch (error) {
+        if (attempt >= maxRetries || !isRateLimitError(error)) {
+          throw error;
+        }
+
+        await sleepFn(retryDelayMs * (attempt + 1));
+      }
+    }
+
+    completed += batchAmount;
+    onProgress?.({
+      batchIndex: index + 1,
+      batchCount: plan.length,
+      batchAmount,
+      completed,
+      total: Math.max(0, Math.trunc(Number(total) || 0)),
+    });
+
+    if (delayMs > 0 && index < plan.length - 1) {
+      await sleepFn(delayMs);
+    }
+  }
+
+  return { batchCount: plan.length, completed };
+}
+
+export async function runInventoryVerifiedGameCommand({
+  tokenStore,
+  tokenId,
+  cmd,
+  itemId,
+  total,
+  createParams,
+  queryInventory,
+  batchSize = HELPER_BATCH_SIZE,
+  timeout = HELPER_COMMAND_TIMEOUT_MS,
+  delayMs = HELPER_BATCH_DELAY_MS,
+  retryDelayMs = HELPER_RETRY_DELAY_MS,
+  maxRetries = HELPER_MAX_RETRIES,
+  sleepFn = sleep,
+  onProgress,
+}) {
+  const targetTotal = Math.max(0, Math.trunc(Number(total) || 0));
+  const initialRoleInfo = await queryInventory();
+  let currentCount = getItemQuantity(initialRoleInfo, itemId);
+
+  if (currentCount < targetTotal) {
+    throw new Error(`库存不足：当前 ${currentCount}，需要 ${targetTotal}`);
+  }
+
+  const initialCount = currentCount;
+  let verifiedConsumed = 0;
+  let verificationIndex = 0;
+
+  while (verifiedConsumed < targetTotal) {
+    verificationIndex += 1;
+    const remaining = targetTotal - verifiedConsumed;
+    const beforeCount = currentCount;
+    const plan = buildTenBatchPlan(remaining, batchSize);
+    let attemptedAmount = 0;
+    let lastStageError = null;
+
+    for (const [index, batchAmount] of plan.entries()) {
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await tokenStore.sendMessageWithPromise(
+            tokenId,
+            cmd,
+            createParams(batchAmount),
+            timeout,
+          );
+          break;
+        } catch (error) {
+          lastStageError = error;
+
+          if (attempt < maxRetries && isRateLimitError(error)) {
+            await sleepFn(retryDelayMs * (attempt + 1));
+            continue;
+          }
+
+          break;
+        }
+      }
+
+      attemptedAmount += batchAmount;
+
+      if (delayMs > 0 && index < plan.length - 1) {
+        await sleepFn(delayMs);
+      }
+    }
+
+    const roleInfo = await queryInventory();
+    currentCount = getItemQuantity(roleInfo, itemId);
+    const totalConsumed = Math.max(0, initialCount - currentCount);
+    const consumed = totalConsumed - verifiedConsumed;
+
+    if (consumed <= 0) {
+      const errorSuffix = lastStageError
+        ? `，最近错误：${getErrorMessage(lastStageError)}`
+        : "";
+      throw new Error(`库存未变化：${cmd} 本次没有消耗道具${errorSuffix}`);
+    }
+
+    verifiedConsumed = totalConsumed;
+    onProgress?.({
+      batchIndex: verificationIndex,
+      batchAmount: attemptedAmount,
+      consumed,
+      completed: Math.min(verifiedConsumed, targetTotal),
+      total: targetTotal,
+      beforeCount,
+      afterCount: currentCount,
+    });
+
+    if (verifiedConsumed < targetTotal && delayMs > 0) {
+      await sleepFn(delayMs);
+    }
+  }
+
+  return {
+    completed: targetTotal,
+    finalCount: currentCount,
+    initialCount,
+  };
+}

--- a/src/utils/towerClimbLimit.js
+++ b/src/utils/towerClimbLimit.js
@@ -1,0 +1,17 @@
+export const DEFAULT_WEIRD_TOWER_MAX_CLIMB = 100;
+
+export function normalizeWeirdTowerMaxClimb(
+  value,
+  fallback = DEFAULT_WEIRD_TOWER_MAX_CLIMB,
+) {
+  const raw = typeof value === "string" ? value.replace(/,/g, "").trim() : value;
+  const numericValue = Number(raw);
+
+  if (!Number.isFinite(numericValue)) {
+    return fallback;
+  }
+
+  const integerValue = Math.trunc(numericValue);
+
+  return integerValue > 0 ? integerValue : fallback;
+}

--- a/src/views/BatchDailyTasks.vue
+++ b/src/views/BatchDailyTasks.vue
@@ -470,6 +470,17 @@
             </n-tab-pane>
             <n-tab-pane name="weirdTower" tab="怪异塔">
               <n-space>
+                <n-input-number
+                  v-model:value="weirdTowerMaxClimb"
+                  class="weird-tower-count-input"
+                  size="small"
+                  :min="1"
+                  :precision="0"
+                  :show-button="false"
+                  placeholder="次数"
+                  :disabled="isRunning"
+                />
+                <span class="weird-tower-count-unit">次</span>
                 <n-button
                   size="small"
                   @click="climbWeirdTower"
@@ -2820,6 +2831,7 @@ import { DailyTaskRunner } from "@/utils/dailyTaskRunner";
 import { preloadQuestions } from "@/utils/studyQuestionsFromJSON.js";
 import { useMessage } from "naive-ui";
 import { Settings } from "@vicons/ionicons5";
+import { DEFAULT_WEIRD_TOWER_MAX_CLIMB } from "@/utils/towerClimbLimit.js";
 
 // Import batch task modules
 import {
@@ -2880,6 +2892,7 @@ import { merchantConfig, goldItemsConfig } from "@/utils/dreamConstants";
 // Initialize token store, message service, and task runner
 const tokenStore = useTokenStore();
 const message = useMessage();
+const weirdTowerMaxClimb = ref(DEFAULT_WEIRD_TOWER_MAX_CLIMB);
 
 // 排序配置（从localStorage读取，与TokenImport共享）
 const savedSortConfig = localStorage.getItem("tokenSortConfig");
@@ -5686,6 +5699,7 @@ const createTaskDeps = () => ({
   // 设置相关
   currentSettings,
   helperSettings,
+  weirdTowerMaxClimb,
   // 功法赠送相关
   recipientIdInput,
   recipientInfo,
@@ -6090,6 +6104,19 @@ const stopBatch = () => {
 .switch-label {
   font-size: 14px;
   color: #666;
+}
+
+.weird-tower-count-input {
+  width: 86px;
+  flex-shrink: 0;
+}
+
+.weird-tower-count-unit {
+  display: inline-flex;
+  align-items: center;
+  height: 28px;
+  color: #666;
+  font-size: 14px;
 }
 
 /* Responsive Design */

--- a/test/helperTaskRunner.test.js
+++ b/test/helperTaskRunner.test.js
@@ -1,0 +1,469 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildTenBatchPlan,
+  getClaimableBoxPoints,
+  getItemQuantity,
+  runInventoryVerifiedGameCommand,
+  runBatchedGameCommand,
+} from "../src/utils/helperTaskRunner.js";
+
+test("buildTenBatchPlan splits totals into ten-sized batches plus remainder", () => {
+  assert.deepEqual(buildTenBatchPlan(10), [10]);
+  assert.deepEqual(buildTenBatchPlan(25), [10, 10, 5]);
+  assert.deepEqual(buildTenBatchPlan(0), []);
+});
+
+test("runBatchedGameCommand sends batches sequentially with delay between batches", async () => {
+  const events = [];
+  const tokenStore = {
+    async sendMessageWithPromise(tokenId, cmd, params, timeout) {
+      events.push({ type: "send", tokenId, cmd, params, timeout });
+      return { ok: true };
+    },
+  };
+
+  await runBatchedGameCommand({
+    tokenStore,
+    tokenId: "token-1",
+    cmd: "hero_recruit",
+    total: 25,
+    timeout: 1234,
+    delayMs: 300,
+    createParams: (amount) => ({ recruitType: 1, recruitNumber: amount }),
+    sleepFn: async (ms) => {
+      events.push({ type: "sleep", ms });
+    },
+    onProgress: (progress) => {
+      events.push({ type: "progress", ...progress });
+    },
+  });
+
+  assert.deepEqual(events, [
+    {
+      type: "send",
+      tokenId: "token-1",
+      cmd: "hero_recruit",
+      params: { recruitType: 1, recruitNumber: 10 },
+      timeout: 1234,
+    },
+    {
+      type: "progress",
+      batchIndex: 1,
+      batchCount: 3,
+      batchAmount: 10,
+      completed: 10,
+      total: 25,
+    },
+    { type: "sleep", ms: 300 },
+    {
+      type: "send",
+      tokenId: "token-1",
+      cmd: "hero_recruit",
+      params: { recruitType: 1, recruitNumber: 10 },
+      timeout: 1234,
+    },
+    {
+      type: "progress",
+      batchIndex: 2,
+      batchCount: 3,
+      batchAmount: 10,
+      completed: 20,
+      total: 25,
+    },
+    { type: "sleep", ms: 300 },
+    {
+      type: "send",
+      tokenId: "token-1",
+      cmd: "hero_recruit",
+      params: { recruitType: 1, recruitNumber: 5 },
+      timeout: 1234,
+    },
+    {
+      type: "progress",
+      batchIndex: 3,
+      batchCount: 3,
+      batchAmount: 5,
+      completed: 25,
+      total: 25,
+    },
+  ]);
+});
+
+test("runBatchedGameCommand propagates command failures", async () => {
+  const tokenStore = {
+    async sendMessageWithPromise() {
+      throw new Error("请求超时");
+    },
+  };
+
+  await assert.rejects(
+    runBatchedGameCommand({
+      tokenStore,
+      tokenId: "token-1",
+      cmd: "item_openbox",
+      total: 10,
+      createParams: (amount) => ({ itemId: 2004, number: amount }),
+      sleepFn: async () => {},
+    }),
+    /请求超时/,
+  );
+});
+
+test("runBatchedGameCommand retries rate-limited batches after backoff", async () => {
+  const events = [];
+  let attempts = 0;
+  const tokenStore = {
+    async sendMessageWithPromise(tokenId, cmd, params) {
+      attempts += 1;
+      events.push({ type: "send", attempts, tokenId, cmd, params });
+
+      if (attempts === 2) {
+        throw new Error("服务器错误: 400312 - 未知错误");
+      }
+
+      return { ok: true };
+    },
+  };
+
+  await runBatchedGameCommand({
+    tokenStore,
+    tokenId: "token-1",
+    cmd: "item_openbox",
+    total: 20,
+    delayMs: 300,
+    retryDelayMs: 1000,
+    maxRetries: 1,
+    createParams: (amount) => ({ itemId: 2004, number: amount }),
+    sleepFn: async (ms) => {
+      events.push({ type: "sleep", ms });
+    },
+  });
+
+  assert.deepEqual(events, [
+    {
+      type: "send",
+      attempts: 1,
+      tokenId: "token-1",
+      cmd: "item_openbox",
+      params: { itemId: 2004, number: 10 },
+    },
+    { type: "sleep", ms: 300 },
+    {
+      type: "send",
+      attempts: 2,
+      tokenId: "token-1",
+      cmd: "item_openbox",
+      params: { itemId: 2004, number: 10 },
+    },
+    { type: "sleep", ms: 1000 },
+    {
+      type: "send",
+      attempts: 3,
+      tokenId: "token-1",
+      cmd: "item_openbox",
+      params: { itemId: 2004, number: 10 },
+    },
+  ]);
+});
+
+test("getItemQuantity reads role item quantities from role info shapes", () => {
+  assert.equal(
+    getItemQuantity({ role: { items: { 2004: { quantity: 12 } } } }, 2004),
+    12,
+  );
+  assert.equal(getItemQuantity({ items: { 1001: { count: 34 } } }, 1001), 34);
+  assert.equal(getItemQuantity({ role: { items: {} } }, 2004), 0);
+});
+
+test("getClaimableBoxPoints reads common role info field shapes", () => {
+  assert.equal(getClaimableBoxPoints({ role: { boxPoint: 1200 } }), 1200);
+  assert.equal(getClaimableBoxPoints({ role: { boxPoints: "1,300" } }), 1300);
+  assert.equal(
+    getClaimableBoxPoints({
+      data: { role: { boxPointReward: { canClaim: 1400 } } },
+    }),
+    1400,
+  );
+  assert.equal(
+    getClaimableBoxPoints({
+      role: { item: { box_points: { quantity: 1500 } } },
+    }),
+    1500,
+  );
+  assert.equal(getClaimableBoxPoints({ role: { items: {} } }), 0);
+});
+
+test("runInventoryVerifiedGameCommand checks inventory after the requested consume plan", async () => {
+  let inventory = 25;
+  const events = [];
+  const tokenStore = {
+    async sendMessageWithPromise(tokenId, cmd, params, timeout) {
+      events.push({ type: "send", tokenId, cmd, params, timeout });
+      inventory -= params.number;
+      return { ok: true };
+    },
+  };
+
+  const result = await runInventoryVerifiedGameCommand({
+    tokenStore,
+    tokenId: "token-1",
+    cmd: "item_openbox",
+    itemId: 2004,
+    total: 20,
+    timeout: 4321,
+    delayMs: 300,
+    createParams: (amount) => ({ itemId: 2004, number: amount }),
+    queryInventory: async () => {
+      events.push({ type: "query", inventory });
+      return { role: { items: { 2004: { quantity: inventory } } } };
+    },
+    sleepFn: async (ms) => {
+      events.push({ type: "sleep", ms });
+    },
+  });
+
+  assert.deepEqual(result, {
+    completed: 20,
+    finalCount: 5,
+    initialCount: 25,
+  });
+  assert.deepEqual(events, [
+    { type: "query", inventory: 25 },
+    {
+      type: "send",
+      tokenId: "token-1",
+      cmd: "item_openbox",
+      params: { itemId: 2004, number: 10 },
+      timeout: 4321,
+    },
+    { type: "sleep", ms: 300 },
+    {
+      type: "send",
+      tokenId: "token-1",
+      cmd: "item_openbox",
+      params: { itemId: 2004, number: 10 },
+      timeout: 4321,
+    },
+    { type: "query", inventory: 5 },
+  ]);
+});
+
+test("runInventoryVerifiedGameCommand sends ten consume calls before rechecking a target of one hundred", async () => {
+  let inventory = 120;
+  const events = [];
+  const tokenStore = {
+    async sendMessageWithPromise(_tokenId, _cmd, params) {
+      events.push({ type: "send", amount: params.number });
+      inventory -= params.number;
+      return { ok: true };
+    },
+  };
+
+  await runInventoryVerifiedGameCommand({
+    tokenStore,
+    tokenId: "token-1",
+    cmd: "item_openbox",
+    itemId: 2004,
+    total: 100,
+    createParams: (amount) => ({ itemId: 2004, number: amount }),
+    queryInventory: async () => {
+      events.push({ type: "query", inventory });
+      return { role: { items: { 2004: { quantity: inventory } } } };
+    },
+    sleepFn: async () => {},
+  });
+
+  assert.deepEqual(events, [
+    { type: "query", inventory: 120 },
+    { type: "send", amount: 10 },
+    { type: "send", amount: 10 },
+    { type: "send", amount: 10 },
+    { type: "send", amount: 10 },
+    { type: "send", amount: 10 },
+    { type: "send", amount: 10 },
+    { type: "send", amount: 10 },
+    { type: "send", amount: 10 },
+    { type: "send", amount: 10 },
+    { type: "send", amount: 10 },
+    { type: "query", inventory: 20 },
+  ]);
+});
+
+test("runInventoryVerifiedGameCommand sends the remaining deficit after a verification check", async () => {
+  let inventory = 25;
+  const events = [];
+  const tokenStore = {
+    async sendMessageWithPromise(_tokenId, _cmd, params) {
+      events.push({ type: "send", amount: params.recruitNumber });
+      inventory -= events.filter((event) => event.type === "send").length === 1
+        ? 6
+        : params.recruitNumber;
+      return { ok: true };
+    },
+  };
+
+  const result = await runInventoryVerifiedGameCommand({
+    tokenStore,
+    tokenId: "token-1",
+    cmd: "hero_recruit",
+    itemId: 1001,
+    total: 20,
+    delayMs: 300,
+    createParams: (amount) => ({ recruitType: 1, recruitNumber: amount }),
+    queryInventory: async () => {
+      events.push({ type: "query", inventory });
+      return { role: { items: { 1001: { quantity: inventory } } } };
+    },
+    sleepFn: async (ms) => {
+      events.push({ type: "sleep", ms });
+    },
+  });
+
+  assert.deepEqual(events, [
+    { type: "query", inventory: 25 },
+    { type: "send", amount: 10 },
+    { type: "sleep", ms: 300 },
+    { type: "send", amount: 10 },
+    { type: "query", inventory: 9 },
+    { type: "sleep", ms: 300 },
+    { type: "send", amount: 4 },
+    { type: "query", inventory: 5 },
+  ]);
+  assert.equal(result.completed, 20);
+  assert.equal(result.finalCount, 5);
+});
+
+test("runInventoryVerifiedGameCommand ignores intermediate send failures and fills the final deficit", async () => {
+  let inventory = 35;
+  const events = [];
+  let sendCount = 0;
+  const tokenStore = {
+    async sendMessageWithPromise(_tokenId, _cmd, params) {
+      sendCount += 1;
+      events.push({ type: "send", amount: params.number, sendCount });
+
+      if (sendCount === 1) {
+        throw new Error("服务器错误: 500000 - 临时失败");
+      }
+
+      inventory -= params.number;
+      return { ok: true };
+    },
+  };
+
+  const result = await runInventoryVerifiedGameCommand({
+    tokenStore,
+    tokenId: "token-1",
+    cmd: "item_openbox",
+    itemId: 2004,
+    total: 20,
+    delayMs: 300,
+    maxRetries: 0,
+    createParams: (amount) => ({ itemId: 2004, number: amount }),
+    queryInventory: async () => {
+      events.push({ type: "query", inventory });
+      return { role: { items: { 2004: { quantity: inventory } } } };
+    },
+    sleepFn: async (ms) => {
+      events.push({ type: "sleep", ms });
+    },
+  });
+
+  assert.deepEqual(events, [
+    { type: "query", inventory: 35 },
+    { type: "send", amount: 10, sendCount: 1 },
+    { type: "sleep", ms: 300 },
+    { type: "send", amount: 10, sendCount: 2 },
+    { type: "query", inventory: 25 },
+    { type: "sleep", ms: 300 },
+    { type: "send", amount: 10, sendCount: 3 },
+    { type: "query", inventory: 15 },
+  ]);
+  assert.equal(result.completed, 20);
+  assert.equal(result.finalCount, 15);
+});
+
+test("runInventoryVerifiedGameCommand does not fill when a failed intermediate call still consumed inventory", async () => {
+  let inventory = 35;
+  let sendCount = 0;
+  const tokenStore = {
+    async sendMessageWithPromise(_tokenId, _cmd, params) {
+      sendCount += 1;
+      inventory -= params.number;
+
+      if (sendCount === 1) {
+        throw new Error("服务器错误: 400312 - 未知错误");
+      }
+
+      return { ok: true };
+    },
+  };
+
+  const result = await runInventoryVerifiedGameCommand({
+    tokenStore,
+    tokenId: "token-1",
+    cmd: "item_openbox",
+    itemId: 2004,
+    total: 20,
+    maxRetries: 0,
+    createParams: (amount) => ({ itemId: 2004, number: amount }),
+    queryInventory: async () => ({
+      role: { items: { 2004: { quantity: inventory } } },
+    }),
+    sleepFn: async () => {},
+  });
+
+  assert.equal(sendCount, 2);
+  assert.equal(result.completed, 20);
+  assert.equal(result.finalCount, 15);
+});
+
+test("runInventoryVerifiedGameCommand stops when verification shows no inventory decrease", async () => {
+  let inventory = 20;
+  const tokenStore = {
+    async sendMessageWithPromise() {
+      return { ok: true };
+    },
+  };
+
+  await assert.rejects(
+    runInventoryVerifiedGameCommand({
+      tokenStore,
+      tokenId: "token-1",
+      cmd: "hero_recruit",
+      itemId: 1001,
+      total: 10,
+      createParams: (amount) => ({ recruitType: 1, recruitNumber: amount }),
+      queryInventory: async () => ({
+        role: { items: { 1001: { quantity: inventory } } },
+      }),
+      sleepFn: async () => {},
+    }),
+    /库存未变化/,
+  );
+});
+
+test("runInventoryVerifiedGameCommand does not consume when inventory is insufficient", async () => {
+  const tokenStore = {
+    async sendMessageWithPromise() {
+      throw new Error("不应该发送消耗命令");
+    },
+  };
+
+  await assert.rejects(
+    runInventoryVerifiedGameCommand({
+      tokenStore,
+      tokenId: "token-1",
+      cmd: "item_openbox",
+      itemId: 2004,
+      total: 20,
+      createParams: (amount) => ({ itemId: 2004, number: amount }),
+      queryInventory: async () => ({
+        role: { items: { 2004: { quantity: 10 } } },
+      }),
+    }),
+    /库存不足/,
+  );
+});

--- a/test/towerClimbLimit.test.js
+++ b/test/towerClimbLimit.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  DEFAULT_WEIRD_TOWER_MAX_CLIMB,
+  normalizeWeirdTowerMaxClimb,
+} from "../src/utils/towerClimbLimit.js";
+
+test("normalizeWeirdTowerMaxClimb defaults to 100 for empty or invalid input", () => {
+  assert.equal(DEFAULT_WEIRD_TOWER_MAX_CLIMB, 100);
+  assert.equal(normalizeWeirdTowerMaxClimb(""), 100);
+  assert.equal(normalizeWeirdTowerMaxClimb("abc"), 100);
+  assert.equal(normalizeWeirdTowerMaxClimb(0), 100);
+  assert.equal(normalizeWeirdTowerMaxClimb(-3), 100);
+});
+
+test("normalizeWeirdTowerMaxClimb accepts positive integer values", () => {
+  assert.equal(normalizeWeirdTowerMaxClimb("35"), 35);
+  assert.equal(normalizeWeirdTowerMaxClimb(12.9), 12);
+  assert.equal(normalizeWeirdTowerMaxClimb("1,200"), 1200);
+});


### PR DESCRIPTION
- 修复宝箱/招募助手批量消耗时可能卡住的问题，改为按库存校验、分批执行、失败重试
- 怪异塔爬塔次数从固定 100 次改为可输入，单号和批量入口默认 100 次并显示“次”单位