### PR TITLE
fix(tower):
  修复怪异塔因未领取章节奖励导致无法爬塔的问题

### DIFF
--- a/src/components/Tower/WeirdTowerStatus.vue
+++ b/src/components/Tower/WeirdTowerStatus.vue
@@ -134,6 +134,20 @@ const currentTowerId = computed(() => {
   return weirdTowerData.value?.towerId || 0
 })
 
+// 已领取到的章号，与已通关章数不一致时游戏服会拒绝开战
+const rewardTowerId = computed(() => {
+  return weirdTowerData.value?.rewardTowerId || 0
+})
+
+// 未领取的章节通关奖励数量：已通关章数(towerId / 10) - 已领章号
+const pendingChapterRewards = computed(() => {
+  const towerId = currentTowerId.value;
+  if (!towerId) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(towerId / 10) - rewardTowerId.value);
+})
+
 const lotteryLeftCnt = computed(() => {
   return weirdTowerData.value?.lotteryLeftCnt || 0
 })
@@ -502,6 +516,9 @@ const startTowerClimb = async () => {
 
   try {
     const tokenId = tokenStore.selectedToken.id;
+    // 爬塔前先补领未领取的章节奖励，否则 evotower_readyfight 会被拒绝（12200020）
+    await claimPendingChapterRewards(tokenId);
+
     for (let i = 0; i < maxClimb; i++) {
       if (stopFlag) break;
 
@@ -519,7 +536,7 @@ const startTowerClimb = async () => {
       );
 
       // 执行战斗
-      const fightResult = await tokenStore.sendMessageWithPromise(
+      await tokenStore.sendMessageWithPromise(
         tokenId,
         "evotower_fight",
         {
@@ -565,24 +582,10 @@ const startTowerClimb = async () => {
         }
       }
 
-      // 检查是否刚通关10层（即当前层是1-1, 2-1, 3-1等）
-      const towerId = currentTowerId.value;
-      const floor = (towerId % 10) + 1;
-      if (
-        fightResult &&
-        fightResult.winList &&
-        fightResult.winList[0] === true &&
-        floor === 1
-      ) {
-        // 领取通关奖励
-        await tokenStore.sendMessageWithPromise(
-          tokenId,
-          "evotower_claimreward",
-          {},
-          5000,
-        );
-        message.success(`成功领取第${Math.floor(towerId / 10)}章通关奖励！`);
-      }
+      // 通关章节奖励：以 rewardTowerId 为准判断是否有未领取的章节
+      // （原按 (towerId % 10) + 1 === 1 判断，towerId 为 10 的整数倍时恒成立，
+      //   会重复发送领奖命令，且无法感知历史未领取的章节）
+      await claimPendingChapterRewards(tokenId);
 
       await new Promise((res) => setTimeout(res, 400)); // 每次间隔400毫秒
     }
@@ -646,6 +649,48 @@ const getTowerInfo = async () => {
   } catch (error) {
     // 获取塔信息失败：静默，避免噪声
   }
+};
+
+/**
+ * 补领未领取的章节通关奖励
+ *
+ * towerId 是层号（如 240 表示已通关第 24 章），rewardTowerId 是已领取到的章号。
+ * 两者不一致时 evotower_readyfight 会被游戏服拒绝并返回 12200020，导致爬塔无法开始，
+ * 因此需在爬塔前先补齐。
+ *
+ * @param {string} tokenId - token id
+ * @returns {Promise<number>} 实际补领的章节数
+ */
+const claimPendingChapterRewards = async (tokenId) => {
+  let pending = pendingChapterRewards.value;
+  if (pending <= 0) {
+    return 0;
+  }
+
+  message.info(`检测到 ${pending} 个未领取的章节奖励，先行补领`);
+  let claimed = 0;
+  while (pending > 0) {
+    try {
+      await tokenStore.sendMessageWithPromise(
+        tokenId,
+        "evotower_claimreward",
+        {},
+        5000,
+      );
+      claimed++;
+      pending--;
+      await new Promise((r) => setTimeout(r, 300));
+    } catch (error) {
+      message.error(`领取章节奖励失败：${error?.message || error}`);
+      break;
+    }
+  }
+
+  if (claimed > 0) {
+    message.success(`已补领 ${claimed} 个章节通关奖励`);
+    await getTowerInfo();
+  }
+  return claimed;
 };
 
 // 监听WebSocket连接状态变化

--- a/src/utils/batch/tasksTower.js
+++ b/src/utils/batch/tasksTower.js
@@ -7,6 +7,62 @@ import { getTowerActId } from "../towerActId.js";
 import { normalizeWeirdTowerMaxClimb } from "../towerClimbLimit.js";
 
 /**
+ * 补领怪异塔未领取的章节通关奖励
+ *
+ * evoTower.towerId 是层号（如 240 表示已通关第 24 章），rewardTowerId 是已领取到的章号。
+ * 两者不一致说明有章节奖励未领取，此时游戏服会拒绝 evotower_readyfight 并返回 12200020，
+ * 导致爬塔无法开始。故需在爬塔前按 rewardTowerId 主动补齐。
+ *
+ * @param {Object} tokenStore - token store
+ * @param {string} tokenId - token id
+ * @param {Object} evoTower - evotower_getinfo 返回的 evoTower 对象
+ * @param {Function} onLog - 日志回调 (message, type) => void
+ * @returns {Promise<number>} 实际补领的章节数
+ */
+async function claimPendingEvoTowerRewards(tokenStore, tokenId, evoTower, onLog) {
+  const towerId = Number(evoTower?.towerId ?? 0);
+  const rewardTowerId = Number(evoTower?.rewardTowerId ?? 0);
+  if (!towerId) {
+    return 0;
+  }
+
+  const clearedChapter = Math.floor(towerId / 10);
+  let pending = clearedChapter - rewardTowerId;
+  if (pending <= 0) {
+    return 0;
+  }
+
+  onLog?.(
+    `检测到 ${pending} 个未领取的章节通关奖励（已通关第 ${clearedChapter} 章，已领至第 ${rewardTowerId} 章），先行补领`,
+    "warning",
+  );
+
+  let claimed = 0;
+  while (pending > 0) {
+    try {
+      const res = await tokenStore.sendMessageWithPromise(
+        tokenId,
+        "evotower_claimreward",
+        {},
+        5000,
+      );
+      claimed++;
+      pending--;
+      onLog?.(`已领取第 ${res?.evoTower?.rewardTowerId ?? rewardTowerId + claimed} 章通关奖励`, "success");
+      await new Promise((r) => setTimeout(r, 300));
+    } catch (error) {
+      // 领奖失败则停止：继续爬塔只会持续返回 12200020
+      onLog?.(
+        `领取章节奖励失败，已补领 ${claimed}/${claimed + pending} 个：${error?.message || error}`,
+        "error",
+      );
+      break;
+    }
+  }
+  return claimed;
+}
+
+/**
  * 创建爬塔类任务执行器
  * @param {Object} deps - 依赖项
  * @returns {Object} 任务函数集合
@@ -362,6 +418,18 @@ export function createTasksTower(deps) {
           type: "info",
         });
 
+        // 爬塔前先补领未领取的章节奖励，否则 evotower_readyfight 会被拒绝（12200020）
+        await claimPendingEvoTowerRewards(
+          tokenStore,
+          tokenId,
+          evotowerinfo1?.evoTower,
+          (message, type) => addLog({
+            time: new Date().toLocaleTimeString(),
+            message: `${token.name} ${message}`,
+            type,
+          }),
+        );
+
         let count = 0;
         const MAX_CLIMB = normalizeWeirdTowerMaxClimb(
           weirdTowerMaxClimb?.value ?? weirdTowerMaxClimb,
@@ -383,7 +451,7 @@ export function createTasksTower(deps) {
               5000,
             );
 
-            const fightResult = await tokenStore.sendMessageWithPromise(
+            await tokenStore.sendMessageWithPromise(
               tokenId,
               "evotower_fight",
               {
@@ -440,28 +508,19 @@ export function createTasksTower(deps) {
                  }
             }
 
-            // 检查是否刚通关10层
-            const towerId = evotowerinfo2?.evoTower?.towerId || 0;
-            const floor = (towerId % 10) + 1;
-            if (
-              fightResult &&
-              fightResult.winList &&
-              fightResult.winList[0] === true &&
-              floor === 1
-            ) {
-              await tokenStore.sendMessageWithPromise(
-                tokenId,
-                "evotower_claimreward",
-                {},
-                5000,
-              );
-              addLog({
+            // 通关章节奖励：以 rewardTowerId 为准判断是否有未领取的章节
+            // （原按 (towerId % 10) + 1 === 1 判断，towerId 为 10 的整数倍时恒成立，
+            //   会重复发送领奖命令，且无法感知历史未领取的章节）
+            await claimPendingEvoTowerRewards(
+              tokenStore,
+              tokenId,
+              evotowerinfo2?.evoTower,
+              (message, type) => addLog({
                 time: new Date().toLocaleTimeString(),
-                message: `${token.name} 成功领取第${Math.floor(towerId / 10)}章通关奖励！`,
-                type: "success",
-              });
-              await new Promise((r) => setTimeout(r, 1000));
-            }
+                message: `${token.name} ${message}`,
+                type,
+              }),
+            );
 
             // 刷新能量
             try {


### PR DESCRIPTION
## 问题

怪异塔存在未领取的章节通关奖励时，点击「开始爬塔」立即报错，批量爬塔任务同样无法执行。

实测游戏服返回 `12200020`：

```
evotower_getinfo    → { towerId: 240, rewardTowerId: 23, energy: 10 }
evotower_readyfight → 服务器错误 12200020
```

`towerId` 是层号（240 表示已通关第 24 章），`rewardTowerId` 是已领取到的章号。
二者不一致说明有章节奖励未领取，此时游戏服拒绝开战。

## 原因

领奖判定用 `(towerId % 10) + 1 === 1` 推断是否处于章末，有三个问题：

1. `towerId` 为 10 的整数倍时该表达式**恒为 1**，会在每轮循环重复发送领奖命令；
2. 完全没有读取 `rewardTowerId`，无法感知历史未领取的章节；
3. 领奖代码位于 `evotower_readyfight` **之后**，而未领奖时 `readyfight` 会先抛错并跳出循环，
   导致永远执行不到领奖 —— 形成「不领奖不能爬塔、不爬塔不会领奖」的死锁。

## 修改

- 新增按 `rewardTowerId` 计算欠账并逐个补领的逻辑（已通关章数 = `towerId / 10`）；
- 在爬塔循环**开始前**先行补领，打破上述死锁；
- 循环内的章末判定改用同一逻辑，不再依赖 `fightResult` 与取模推断。

`src/utils/batch/tasksTower.js`（批量任务 `climbWeirdTower`）与
`src/components/Tower/WeirdTowerStatus.vue`（怪异塔卡片）为同源缺陷，一并修复。

## 验证

实测闭环：`readyfight` 报 12200020 → 补领奖励（`rewardTowerId` 23 → 24）→
`readyfight` 立即成功返回战斗数据 → 连续爬塔 3 层正常（`towerId` 240 → 243，体力 10 → 7）。

`pnpm build` 通过。
